### PR TITLE
Reset dev head to main on merge + small POST user bugfix

### DIFF
--- a/.github/workflows/reset-dev-branch.yml
+++ b/.github/workflows/reset-dev-branch.yml
@@ -1,0 +1,27 @@
+name: Reset Dev Branch After Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  reset-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # Using default GITHUB_TOKEN which has permissions to push to non-protected branches
+          
+      - name: Setup Git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          
+      - name: Reset dev branch to main
+        run: |
+          git checkout dev
+          git reset --hard origin/main
+          git push -f origin dev

--- a/endpoints/users.py
+++ b/endpoints/users.py
@@ -24,7 +24,7 @@ def create_user():
     if user is not None and user.is_active:
         return "Id already exists", 400
     
-    if not user.is_active:
+    if user is not None and not user.is_active:
         user.runescape_name = data.runescape_name
         user.previous_names = data.previous_names
         user.is_member = data.is_member


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to reset the development branch after a merge into the main branch, and it also includes a small bug fix in the user creation endpoint.

New GitHub Actions Workflow:

* [`.github/workflows/reset-dev-branch.yml`](diffhunk://#diff-ea001bbba434ac21bb379d92a7243e879bff0fa35211e3cf2de05258d6558dd2R1-R27): Added a workflow to reset the `dev` branch to match the `main` branch after each push to `main`. This includes steps to check out the repository, set up Git, and force push the reset `dev` branch.

Bug Fix:

* [`endpoints/users.py`](diffhunk://#diff-ae553b7946fcdba7c0d8964848877b621bdccb3e6a46be2482bbea14886ae511L27-R27): Fixed a bug in the `create_user` function where the code did not correctly handle the case when a user is not active. The condition now correctly checks if the user is not `None` and not active before updating user details.