### PR TITLE
fix: add diary name to application diary creation

### DIFF
--- a/endpoints/applications.py
+++ b/endpoints/applications.py
@@ -160,6 +160,7 @@ def create_application_diary():
     
     data.user_id = user.discord_id
     data.runescape_name = user.runescape_name
+    data.diary_name = diary[0].diary_name # All diaries with the same shorthand have the same name
 
     if diary[0].scale is not None:
         try:


### PR DESCRIPTION
This pull request includes a small change to the `create_application_diary` function in the `endpoints/applications.py` file. The change assigns the `diary_name` to the `data` object using the first element of the `diary` list.

Change details:

* [`endpoints/applications.py`](diffhunk://#diff-3c9dd44c06fc0f55a834ba38bfe59a75b156826f5bb3d6788d8a5e1ec626357eR163): Added assignment of `diary_name` to `data` object in `create_application_diary` function.