### PR TITLE
Splits truncate contribution

### DIFF
--- a/endpoints/splits.py
+++ b/endpoints/splits.py
@@ -14,9 +14,14 @@ def create_split():
     if user is None:
         return "Could not find User", 404
     data.id = None
-    if int(data.group_size) == 0:
-        return "Group size cannot be zero", 400
-    data.split_contribution = (int(data.item_price) / int(data.group_size)) * (int(data.group_size) - 1)
+    if int(data.group_size) <= 0:
+        return "Group size cannot be less than or equal to zero", 400
+    if int(data.item_price) <= 0:
+        return "Item price cannot be less than or equal to zero", 400
+    split_per_person = int(data.item_price) / int(data.group_size)
+    if split_per_person < 1_000_000:
+        return "Split per person cannot be less than 1,000,000", 400
+    data.split_contribution = int((int(data.item_price) / int(data.group_size)) * (int(data.group_size) - 1)) # Truncating the split contribution to the nearest integer
 
     split_points = data.split_contribution * (10 / 4_000_000)
     split_points = round(split_points, 2)

--- a/models/models.py
+++ b/models/models.py
@@ -10,6 +10,7 @@ class Users(db.Model, Serializer):
     discord_id = db.Column(db.String, unique=True, nullable=False)
     runescape_name = db.Column(db.String, nullable=False)
     previous_names = db.Column(ARRAY(db.String))
+    alt_names = db.Column(ARRAY(db.String))
     is_member = db.Column(db.Boolean)
     rank = db.Column(db.String)
     rank_points = db.Column(db.Integer)
@@ -22,6 +23,7 @@ class Users(db.Model, Serializer):
     event_points = db.Column(db.Integer, default=0)
     time_points = db.Column(db.Integer, default=0)
     split_points = db.Column(db.Integer, default=0)
+    settings = db.Column(JSONB, default={})
 
     def serialize(self):
         return Serializer.serialize(self)

--- a/static/swagger/users.json
+++ b/static/swagger/users.json
@@ -22,6 +22,7 @@
                     "discord_id": "12345",
                     "runescape_name": "TestUser",
                     "previous_names": ["UserTester", "TesterUser"],
+                    "alt_names": null,
                     "is_member": true,
                     "rank": "Quester",
                     "rank_points": 0,
@@ -29,13 +30,19 @@
                     "achievements": null,
                     "join_date": "2025-03-28T11:23:59.642101",
                     "timestamp": "2025-03-28T11:22:00.718276",
-                    "is_active": true
+                    "is_active": true,
+                    "diary_points": 0,
+                    "event_points": 0,
+                    "time_points": 0,
+                    "split_points": 0,
+                    "settings": {}
                   },
                   {
                     "id": "1c715e03328043c9a8aa4e3c55db112c",
                     "discord_id": "54321",
                     "runescape_name": "Funzip",
                     "previous_names": null,
+                    "alt_names": null,
                     "is_member": true,
                     "rank": "Trialist",
                     "rank_points": 375,
@@ -43,7 +50,12 @@
                     "achievements": ["Infernal Cape", "Grandmaster Combat Achiever"],
                     "join_date": "2024-03-29T01:03:22.101679",
                     "timestamp": "2025-03-29T01:01:45.054974",
-                    "is_active": true
+                    "is_active": true,
+                    "diary_points": 0,
+                    "event_points": 0,
+                    "time_points": 0,
+                    "split_points": 0,
+                    "settings": {}
                   }
                 ]
               }
@@ -114,6 +126,59 @@
           }
         }
       }
+    },
+    "/users/{id}/rename": {
+      "put": {
+        "tags": ["users"],
+        "summary": "Rename a user",
+        "description": "Renames a user and updates their previous names list",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Discord ID of the user to rename",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "runescape_name": {
+                    "type": "string",
+                    "description": "New RuneScape name for the user"
+                  }
+                },
+                "required": ["runescape_name"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User renamed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input or no JSON received"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -137,6 +202,12 @@
               "type": "string"
             }
           },
+          "alt_names": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            }
+          },
           "is_member": {
             "type": "boolean"
           },
@@ -150,7 +221,10 @@
             "type": ["object", "null"]
           },
           "achievements": {
-            "type": ["array", "null"]
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            }
           },
           "join_date": {
             "type": "string",
@@ -162,6 +236,26 @@
           },
           "is_active": {
             "type": "boolean"
+          },
+          "diary_points": {
+            "type": "integer",
+            "default": 0
+          },
+          "event_points": {
+            "type": "integer",
+            "default": 0
+          },
+          "time_points": {
+            "type": "integer",
+            "default": 0
+          },
+          "split_points": {
+            "type": "integer",
+            "default": 0
+          },
+          "settings": {
+            "type": "object",
+            "default": {}
           }
         }
       }


### PR DESCRIPTION
This pull request introduces several changes to improve user management and validation in the application. The most important changes include updates to the `create_split` function, the addition of a new endpoint for renaming users, and modifications to the `Users` model and its corresponding Swagger documentation.

### User Management Enhancements:

* [`endpoints/users.py`](diffhunk://#diff-ae553b7946fcdba7c0d8964848877b621bdccb3e6a46be2482bbea14886ae511R106-R130): Added a new endpoint `rename_user` to allow renaming users and updating their previous names list. The endpoint also ensures no duplicate or blank entries in the previous names.

### Validation Improvements:

* [`endpoints/splits.py`](diffhunk://#diff-4cd1da8428f52e8d3a7208358ded2582fc3de0e984f088340d4855fc5c99cbb8L17-R24): Enhanced the `create_split` function by adding validation checks for `group_size` and `item_price` to ensure they are greater than zero. Additionally, added a check to ensure the split per person is not less than 1,000,000.

### Model Updates:

* [`models/models.py`](diffhunk://#diff-f8c536b2618f73297f8c97fd3bc5fd058be8a795af500792953355ed6be1d989R13): Added `alt_names` and `settings` columns to the `Users` model to store alternate names and user settings, respectively. [[1]](diffhunk://#diff-f8c536b2618f73297f8c97fd3bc5fd058be8a795af500792953355ed6be1d989R13) [[2]](diffhunk://#diff-f8c536b2618f73297f8c97fd3bc5fd058be8a795af500792953355ed6be1d989R26)

### Swagger Documentation Updates:

* [`static/swagger/users.json`](diffhunk://#diff-15db56b7086ba78b37fc00bb7f2d555ca0a97ad8b964201e12bddce8d9aef2f9R25-R58): Updated the Swagger documentation to reflect the new `rename_user` endpoint, the addition of `alt_names` and `settings` fields, and the inclusion of new points fields (`diary_points`, `event_points`, `time_points`, `split_points`). [[1]](diffhunk://#diff-15db56b7086ba78b37fc00bb7f2d555ca0a97ad8b964201e12bddce8d9aef2f9R25-R58) [[2]](diffhunk://#diff-15db56b7086ba78b37fc00bb7f2d555ca0a97ad8b964201e12bddce8d9aef2f9R129-R181) [[3]](diffhunk://#diff-15db56b7086ba78b37fc00bb7f2d555ca0a97ad8b964201e12bddce8d9aef2f9R205-R210) [[4]](diffhunk://#diff-15db56b7086ba78b37fc00bb7f2d555ca0a97ad8b964201e12bddce8d9aef2f9L153-R227) [[5]](diffhunk://#diff-15db56b7086ba78b37fc00bb7f2d555ca0a97ad8b964201e12bddce8d9aef2f9R239-R258)